### PR TITLE
Add support for proposal elogs

### DIFF
--- a/elog_zulip/elog.py
+++ b/elog_zulip/elog.py
@@ -130,7 +130,7 @@ class Elog(mechanize.Browser):
 
         # elog entry text
         text = soup.find('td', class_='messageframe')
-        md_text = pypandoc.convert_text(text, to='markdown_github', format='html')
+        md_text = pypandoc.convert_text(text, to='gfm', format='html')
         text = trim_lines(md_text)
         text = re.sub(r'\\(.)', r'\1', text)
 

--- a/elog_zulip/elog.py
+++ b/elog_zulip/elog.py
@@ -310,7 +310,7 @@ def main(argv=None):
 
         if elog == "XO":
             Publisher = ElogXO
-        elif elog == "Operation":
+        elif elog.startswith("Operation"):
             Publisher = ElogOperation
         elif elog == "Doc":
             Publisher = ElogDoc


### PR DESCRIPTION
I implemented `ElogProposal` to handle elogs for proposal elogs. Differences from the other elog classes are:
- The topic is set to the category of the entry rather than being hardcoded.
- The messages aren't quoted, I thought it looked nicer that way.
- If the database doesn't have any entries for it yet, it retrieves _all_ the elog entries. This is in case a bot is added after a proposal has already started, in which case it makes sense to get all previous entries.
- I put the lab coat :lab_coat: emoji in front of the title for sneaky test reasons :stuck_out_tongue:

There are some other minor changes. Should be possible to review each commit individually, I tried to keep them atomic.