### PR TITLE
Implements user impersonation and the ability to set a custom date.

### DIFF
--- a/elog_zulip/__init__.py
+++ b/elog_zulip/__init__.py
@@ -6,8 +6,9 @@ import os
 import re
 import sys
 import warnings
-import datetime
+
 import csv
+import datetime
 from argparse import ArgumentParser
 from io import BytesIO
 from pathlib import Path
@@ -56,6 +57,7 @@ class Elog:
     def __init__(self, config, dry_run=False):
         user, pswd = config.get('elog-credentials', (None, ''))
         url = config['elog-url']
+
         self.logbook = Logbook(url, user=user, password=pswd)
 
         self.table = config['db-table']
@@ -64,6 +66,7 @@ class Elog:
         users_map_path = config.get('users-map')
         can_create_users = config.get('can-create-users', False)
         self.rewrite_datetime = config.get('use-elog-datetime', False)
+        self._fallback_user = 'me@example.com'
         self.config = config
 
         self.dry_run = dry_run
@@ -75,47 +78,62 @@ class Elog:
             # zulip client
             self.zulip = zulip.Client(
                     config_file=config['zulip-rc'],
-                    insecure=True,
+                    # Option to make the software work even if the HTTPS certificate is not valid
+                    insecure=config.get('allow-insecure-zulip', False),
+                    # Only when passing certain client name the API allows the client to impersonate people
                     client='jabber_mirror' if self.impersonate else None
                     )
             # database connection
             self._db = dataset.connect(config['database'])
             self.entry = self._db[self.table]
 
-            if not can_create_users:
-                response = self.zulip.get_members()
-                if response['result'] == 'success':
-                    self._existing_users = { m['email'] : m for m in response['members'] }
+            self._fallback_user = self.zulip.get_profile()['email']
+
+            if self.impersonate:
+                if users_map_path:
+
+                    existing_users = {}
+
+                    if not can_create_users:
+
+                        response = self.zulip.get_members()
+
+                        if response['result'] == 'success':
+                            existing_users = { m['email'] : m for m in response['members'] }
+                        else:
+                            log.error(f'Error while querying the users: {response["msg"]}')
+                            sys.exit(1)
+
+
+                    with open(users_map_path, newline='') as f:
+
+                        data = list(csv.reader(f))
+                        h = data[0]
+                        self._users_map = {}
+
+                        if len(data) < 2:
+                            log.error(f'The provided user map is empty. Please provide a valid one.')
+                            sys.exit(1)
+
+                        if not ('elog_user' in h and 'email' in h):
+                            log.error(f'The users map needs to have an header with two fields: "elog_user" (name of the user in the elog) and "email" (email of the user in the destination zulip system)')
+                            sys.exit(1)
+
+                        for d in data[1:]:
+                            user_dict = dict(zip(h, d))
+
+                            if not can_create_users and user_dict['email'] not in existing_users:
+                                log.info(f'User {user_dict["email"]} is not present in the server skipping.')
+                                continue
+
+                            self._users_map[user_dict['elog_user']] = user_dict
+
+                        if len(self._users_map) == 0:
+                            log.error(f'No user found in the user map. Please check that you are using the correct user map for this elog.')
+                            sys.exit(1)
                 else:
-                    log.error(f'Error while querying the users: {response["msg"]}')
+                    log.error(f'Cannot proceed without a users map')
                     sys.exit(1)
-
-
-        if self.impersonate:
-            if users_map_path:
-                with open(users_map_path, newline='') as f:
-                    data = list(csv.reader(f))
-                    h = data[0]
-                    self._users_map = {}
-                    if len(data) < 2:
-                        log.error(f'The provided user map is empty. Please provide a valid one.')
-                        sys.exit(1)
-
-                    for d in data[1:]:
-                        user_dict = dict(zip(h, d))
-
-                        if not can_create_users and user_dict['email'] not in self._existing_users:
-                            log.info(f'User {user_dict["email"]} is not present in the server skipping.')
-                            continue
-
-                        self._users_map[user_dict['elog_user']] = user_dict
-
-                    if len(self._users_map) == 0:
-                        log.error(f'No user found in the user map. Please check that you are using the correct user map for this elog.')
-                        sys.exit(1)
-            else:
-                log.error(f'Cannot proceed without a users map')
-                sys.exit(1)
 
     def _saved_entries(self):
         return {int(e['entry_id']) for e in self.entry.find(order_by=['entry_id']) or ()}
@@ -200,7 +218,7 @@ class Elog:
         sender = None
         if self.impersonate and self._users_map:
             a = attributes['Author']
-            sender = self.zulip.get_profile()['email']
+            sender = self._fallback_user
             if a in self._users_map:
                 sender = self._users_map[a]['email']
 

--- a/elog_zulip/__init__.py
+++ b/elog_zulip/__init__.py
@@ -2,13 +2,12 @@
 """
 __version__ = "0.2.0"
 
+import csv
+import datetime
 import os
 import re
 import sys
 import warnings
-
-import csv
-import datetime
 from argparse import ArgumentParser
 from io import BytesIO
 from pathlib import Path

--- a/elog_zulip/__init__.py
+++ b/elog_zulip/__init__.py
@@ -4,7 +4,10 @@ __version__ = "0.2.0"
 
 import os
 import re
+import sys
 import warnings
+import datetime
+import csv
 from argparse import ArgumentParser
 from io import BytesIO
 from pathlib import Path
@@ -57,18 +60,62 @@ class Elog:
 
         self.table = config['db-table']
         self.stream = config['zulip-stream']
+        self.impersonate = config.get('use-elog-user', False)
+        users_map_path = config.get('users-map')
+        can_create_users = config.get('can-create-users', False)
+        self.rewrite_datetime = config.get('use-elog-datetime', False)
         self.config = config
 
         self.dry_run = dry_run
         if dry_run:
             self.entry = FakeDB()
             self.zulip = FakeZulip()
+            can_create_users = True
         else:
             # zulip client
-            self.zulip = zulip.Client(config_file=config['zulip-rc'])
+            self.zulip = zulip.Client(
+                    config_file=config['zulip-rc'],
+                    insecure=True,
+                    client='jabber_mirror' if self.impersonate else None
+                    )
             # database connection
             self._db = dataset.connect(config['database'])
             self.entry = self._db[self.table]
+
+            if not can_create_users:
+                response = self.zulip.get_members()
+                if response['result'] == 'success':
+                    self._existing_users = { m['email'] : m for m in response['members'] }
+                else:
+                    log.error(f'Error while querying the users: {response["msg"]}')
+                    sys.exit(1)
+
+
+        if self.impersonate:
+            if users_map_path:
+                with open(users_map_path, newline='') as f:
+                    data = list(csv.reader(f))
+                    h = data[0]
+                    self._users_map = {}
+                    if len(data) < 2:
+                        log.error(f'The provided user map is empty. Please provide a valid one.')
+                        sys.exit(1)
+
+                    for d in data[1:]:
+                        user_dict = dict(zip(h, d))
+
+                        if not can_create_users and user_dict['email'] not in self._existing_users:
+                            log.info(f'User {user_dict["email"]} is not present in the server skipping.')
+                            continue
+
+                        self._users_map[user_dict['elog_user']] = user_dict
+
+                    if len(self._users_map) == 0:
+                        log.error(f'No user found in the user map. Please check that you are using the correct user map for this elog.')
+                        sys.exit(1)
+            else:
+                log.error(f'Cannot proceed without a users map')
+                sys.exit(1)
 
     def _saved_entries(self):
         return {int(e['entry_id']) for e in self.entry.find(order_by=['entry_id']) or ()}
@@ -126,7 +173,7 @@ class Elog:
         ret += '```\n'
         return ret
 
-    def _send_message(self, message, topic):
+    def _send_message(self, message, topic, sender = None, date = None):
         log.info(message)
         log.info(f'sending to #{self.stream}>>{topic}')
         request = {
@@ -137,11 +184,31 @@ class Elog:
             "topic": topic,
             "content": message,
         }
+        if sender is not None:
+            request['sender'] = sender
+
+        if date is not None:
+            request['forged'] = True
+            request['time'] = date.timestamp()
+
         res = _handle_z_error(self.zulip.send_message, request)
         return res
 
     def _publish(self, text, attributes, attachments, maxchar=10_000):
         header = self._default_header(attributes)
+
+        sender = None
+        if self.impersonate and self._users_map:
+            a = attributes['Author']
+            sender = self.zulip.get_profile()['email']
+            if a in self._users_map:
+                sender = self._users_map[a]['email']
+
+        try:
+            date = datetime.datetime.strptime(attributes['Date'], '%a, %d %b %Y %H:%M:%S %z') if self.rewrite_datetime else None
+        except ValueError as e:
+            log.warning(f'Ignoring invalid date {attributes["Date"]}')
+            date = None
 
         attributes['EntryUrl'] = self.entry_url(attributes)
         attributes['EntryID'] = attributes['$@MID@$']
@@ -212,7 +279,7 @@ class Elog:
 
         def _send_message(txt):
             txt = _replace_attachments_in_table(txt)
-            r = self._send_message(txt, topic)
+            r = self._send_message(txt, topic, sender, date)
             log.info(f'New publication: {self.entry_url(attributes)} - {r}')
 
         # combine parts and send to zulip
@@ -271,5 +338,4 @@ def main(argv=None):
 
 
 if __name__ == '__main__':
-    import sys
     main(sys.argv[1:])

--- a/elog_zulip/__init__.py
+++ b/elog_zulip/__init__.py
@@ -107,7 +107,7 @@ class Elog:
                 log.error(f'Error while querying the users: {response["msg"]}')
                 sys.exit(1)
 
-        with open(self.config.get('user-map'), newline='') as f:
+        with open(self.config.get('users-map'), newline='') as f:
             data = list(csv.reader(f))
 
         if len(data) < 2:

--- a/elog_zulip/__init__.py
+++ b/elog_zulip/__init__.py
@@ -86,14 +86,30 @@ class Elog:
             self._db = dataset.connect(config['database'])
             self.entry = self._db[self.table]
 
-        self._fallback_user = self.zulip.get_profile()['email']
+        self._fallback_user = config.get('default-impersonator', self.zulip.get_profile()['email'])
+
+        if not self._get_user_by_email(self._fallback_user):
+            log.error(f'The impersonation default user {self._fallback_user} does not exist on the server.')
+            sys.exit(1)
 
         self._users_map = {}
         if self.impersonate:
             if not users_map_path:
-                log.error(f'Cannot proceed without a users map')
+                log.error('Cannot proceed without a users map')
                 sys.exit(1)
             self._load_elog_user_map()
+
+    def _get_user_by_email(self, user):
+        response = self.zulip.call_endpoint(
+            url=f"/users/{user}",
+            method="GET",
+        )
+
+        if response['result'] == 'success':
+            return response['user']
+
+        return {}
+
 
     def _load_elog_user_map(self):
         can_create_users = self.config.get('can-create-users', False)

--- a/elog_zulip/__init__.py
+++ b/elog_zulip/__init__.py
@@ -86,53 +86,55 @@ class Elog:
             self._db = dataset.connect(config['database'])
             self.entry = self._db[self.table]
 
-            self._fallback_user = self.zulip.get_profile()['email']
+        self._fallback_user = self.zulip.get_profile()['email']
 
-            if self.impersonate:
-                if users_map_path:
+        self._users_map = {}
+        if self.impersonate:
+            if not users_map_path:
+                log.error(f'Cannot proceed without a users map')
+                sys.exit(1)
+            self._load_elog_user_map()
 
-                    existing_users = {}
+    def _load_elog_user_map(self):
+        can_create_users = self.config.get('can-create-users', False)
+        existing_users = {}
 
-                    if not can_create_users:
+        if not can_create_users:
+            response = self.zulip.get_members()
+            if response['result'] == 'success':
+                existing_users = { m['email'] : m for m in response['members'] }
+            else:
+                log.error(f'Error while querying the users: {response["msg"]}')
+                sys.exit(1)
 
-                        response = self.zulip.get_members()
+        with open(self.config.get('user-map'), newline='') as f:
+            data = list(csv.reader(f))
 
-                        if response['result'] == 'success':
-                            existing_users = { m['email'] : m for m in response['members'] }
-                        else:
-                            log.error(f'Error while querying the users: {response["msg"]}')
-                            sys.exit(1)
+        if len(data) < 2:
+            log.error(f'The provided user map is empty. Please provide a valid one.')
+            sys.exit(1)
 
+        header = data[0]
 
-                    with open(users_map_path, newline='') as f:
+        if not ('elog_user' in header and 'email' in header):
+            log.error(
+                f'The users map needs to have an header with two fields:'
+                '"elog_user" (name of the user in the elog) and "email" (email of '
+                 'the user in the destination zulip system)')
+            sys.exit(1)
 
-                        data = list(csv.reader(f))
-                        h = data[0]
-                        self._users_map = {}
+        for d in data[1:]:
+            user_dict = dict(zip(header, d))
 
-                        if len(data) < 2:
-                            log.error(f'The provided user map is empty. Please provide a valid one.')
-                            sys.exit(1)
+            if not can_create_users and user_dict['email'] not in existing_users:
+                log.info(f'User {user_dict["email"]} is not present in the server skipping.')
+                continue
 
-                        if not ('elog_user' in h and 'email' in h):
-                            log.error(f'The users map needs to have an header with two fields: "elog_user" (name of the user in the elog) and "email" (email of the user in the destination zulip system)')
-                            sys.exit(1)
+            self._users_map[user_dict['elog_user']] = user_dict
 
-                        for d in data[1:]:
-                            user_dict = dict(zip(h, d))
-
-                            if not can_create_users and user_dict['email'] not in existing_users:
-                                log.info(f'User {user_dict["email"]} is not present in the server skipping.')
-                                continue
-
-                            self._users_map[user_dict['elog_user']] = user_dict
-
-                        if len(self._users_map) == 0:
-                            log.error(f'No user found in the user map. Please check that you are using the correct user map for this elog.')
-                            sys.exit(1)
-                else:
-                    log.error(f'Cannot proceed without a users map')
-                    sys.exit(1)
+        if len(self._users_map) == 0:
+            log.error(f'No user found in the user map. Please check that you are using the correct user map for this elog.')
+            sys.exit(1)
 
     def _saved_entries(self):
         return {int(e['entry_id']) for e in self.entry.find(order_by=['entry_id']) or ()}

--- a/elog_zulip/mock.py
+++ b/elog_zulip/mock.py
@@ -22,3 +22,7 @@ class FakeZulip:
 
     def upload_file(self, file):
         return {'result': 'success', 'uri': 'https://example.com'}
+
+    def get_profile(self):
+        log.info(f'Getting profile')
+        return {'result': 'success', 'user_id': 1, 'full_name': 'Example example', 'email': 'me@example.com'}

--- a/elog_zulip/mock.py
+++ b/elog_zulip/mock.py
@@ -23,6 +23,3 @@ class FakeZulip:
     def upload_file(self, file):
         return {'result': 'success', 'uri': 'https://example.com'}
 
-    def get_profile(self):
-        log.info(f'Getting profile')
-        return {'result': 'success', 'user_id': 1, 'full_name': 'Example example', 'email': 'me@example.com'}


### PR DESCRIPTION
This patch implements user impersonation and dates preservation when importing the messages to Zulip.
Options are implemented to:
- enable/disable user impersonation
- allow zulip to create new users for missing ones
- define a map from elog users to zulip users
- enable/disable date preservation